### PR TITLE
fixes quality gate retrieval for projectsKey with url-protected characters

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarInstallation.java
@@ -52,7 +52,7 @@ public class SonarInstallation implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  public static final String DEFAULT_SERVER_URL = "http://locahost:9000";
+  public static final String DEFAULT_SERVER_URL = "http://localhost:9000";
 
   private final String name;
   private final String serverUrl;

--- a/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
+++ b/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
@@ -23,6 +23,9 @@ import hudson.plugins.sonar.client.WsClient.CETask;
 import hudson.plugins.sonar.client.WsClient.ProjectQualityGate;
 import hudson.plugins.sonar.utils.Logger;
 import hudson.plugins.sonar.utils.Version;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Locale;
 import java.util.logging.Level;
 import javax.annotation.CheckForNull;
@@ -138,6 +141,15 @@ public class SQProjectResolver {
 
   @CheckForNull
   static String extractProjectKey(@Nullable String url) {
-    return StringUtils.substringAfterLast(url, "/dashboard/index/");
+      try {
+          //the key is already url-encoded when being extracted from the dashboard url
+          //because the key is always encoded before being used in an URL, we need
+          //decode it here, otherwise already-url-encoded characters will be encoded again
+          // i.e. %2f -> %252f
+          return URLDecoder.decode(StringUtils.substringAfterLast(url, "/dashboard/index/"), "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+          //fall back to undecoded key
+          return StringUtils.substringAfterLast(url, "/dashboard/index/");
+      }
   }
 }

--- a/src/test/java/hudson/plugins/sonar/client/SQProjectResolverTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/SQProjectResolverTest.java
@@ -95,6 +95,19 @@ public class SQProjectResolverTest extends SonarTestCase {
   }
 
   @Test
+  public void testProjectUrlWithEncodedChars() throws Exception {
+    mockSQServer54();
+    //the url points to a branch-build that uses a [branch-category]/[issue-name] pattern
+    //the %2F is an encoded / and must be decoded properly otherwise the project key is wrong
+    String projectKeyWithEncodedChar = "baseProjectKey:branchPrefix%2FSOME-123-Branchname";
+    String projectUrl = SERVER_URL + "/dashboard/index/" + projectKeyWithEncodedChar;
+
+    ProjectInformation proj = resolver.resolve(projectUrl, CE_TASK_ID, SONAR_INSTALLATION_NAME);
+
+    assertThat(proj.getProjectKey()).isEqualTo("baseProjectKey:branchPrefix/SOME-123-Branchname");
+  }
+
+  @Test
   public void testSQ54NoCETask() throws Exception {
     mockSQServer54();
     when(client.getHttp(startsWith(SERVER_URL + WsClient.API_PROJECT_NAME), eq(TOKEN), isNull(String.class))).thenReturn(getFile("projectIndex.json"));


### PR DESCRIPTION
This PR contains a fix, that url-decodes the project key after being extracted from the project url.

If the project key contains characters that need to be encoded in URLs (i.e. when running multibranch builds and the branch name contains a / like bugfix/ISSUE-123) fetching the quality gate information fails with a 404 because the projectKey is extracted from the project url (alreay encoded!) and then encoded again when the url to fetch the quality gate is assembled. 

Further it fixes the default sonar URL which contained a typo. Although this is unrelated to the original issue, it popped up during test development and was apparently wrong.