### PR TITLE
removing obsolete reference

### DIFF
--- a/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
@@ -1,8 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-         
-  <script type="text/javascript" src="${rootURL}/plugin/sonar/js/global_config.js" />
   
   <f:section title="${%Title}">
     <f:entry title="${%InjectVarsTitle}" description="${%InjectVarsDesc}">


### PR DESCRIPTION
File global_config.js was removed in PR "SONARJNKNS-293 Drop support of SQ < 5.6" at 3/16/2018 , but reference to the file remained in global configuration page.
This PR just remove obsolete reference.

I develop plugin that do integration with sonarqube-plugin, our tests on configuration page failed with the exception : 
SEVERE	c.g.htmlunit.html.HtmlPage#loadExternalJavaScriptFile: Error loading JavaScript from [http://localhost:63932/jenkins/plugin/sonar/js/global_config.js].
com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException: 404 Not Found for http://localhost:63932/jenkins/plugin/sonar/js/global_config.js

The test is very simple
 @Rule
  public JenkinsRule jenkins = new JenkinsRule();
  
  @Test
  public void OpenConfigurationPageTest(){

      JenkinsRule.WebClient client = jenkins.createWebClient();
      HtmlPage configPage = client.goTo("configure");
      HtmlForm form = configPage.getFormByName("config");
}


