### PR TITLE
[JENKINS-69464] Cannot configure msBuildSQRunnerInstallation global tool using JCASC

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,0 +1,4 @@
+load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+
+def main(ctx):
+    return load_features(ctx, features=["vault"])

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
 load("github.com/SonarSource/cirrus-modules@v2", "load_features")
 
 def main(ctx):
-    return load_features(ctx, features=["vault"])
+    return load_features(ctx)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ build_task:
     memory: 3G
   env:
     SONAR_TOKEN: VAULT[development/kv/data/next data.token]
-    SONAR_HOST_URL: https://next.sonarqube.com/sonarqube
+    SONAR_HOST_URL: VAULT[development/kv/data/next data.url]
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,7 @@ env:
   ### Project variables
   DEPLOY_PULL_REQUEST: true
   ARTIFACTS: org.jenkins-ci.plugins:sonar:hpi
+  NIGHTLY_CRON: 'nightly-cron'
 
 #
 # RE-USABLE CONFIGS
@@ -49,6 +50,9 @@ container_template: &STD_CONTAINER_TEMPLATE
 
 only_qa: &ONLY_QA
   only_if: $CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*"
+
+except_nightly_cron: &EXCEPT_ON_NIGHTLY_CRON
+  only_if: $CIRRUS_CRON != $NIGHTLY_CRON
 
 #
 # TASKS
@@ -102,6 +106,7 @@ promote_task:
   depends_on:
     - linux_qa
   <<: *ONLY_QA
+  <<: *EXCEPT_ON_NIGHTLY_CRON
   eks_container:
     <<: *STD_CONTAINER_TEMPLATE
     cpu: 0.5

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,22 +6,20 @@ gcp_credentials: ENCRYPTED[!e5f7207bd8d02d383733bef47e18296ac32e3b7d22eb480354e8
 #
 env:
   ### Shared variables
-  ARTIFACTORY_URL: ENCRYPTED[!2f8fa307d3289faa0aa6791f18b961627ae44f1ef46b136e1a1e63b0b4c86454dbb25520d49b339e2d50a1e1e5f95c88!]
-  ARTIFACTORY_PRIVATE_USERNAME: repox-private-reader-sq-ef42e7
-  ARTIFACTORY_PRIVATE_PASSWORD: ENCRYPTED[!bdffdd216a1b768605552475d16e8a5cedd97acbf8ca0aeb7256eaf98a2bc54f752c6c1be5391531742ebfee0cbd2ccf!]
-  ARTIFACTORY_API_KEY: ENCRYPTED[!bdffdd216a1b768605552475d16e8a5cedd97acbf8ca0aeb7256eaf98a2bc54f752c6c1be5391531742ebfee0cbd2ccf!]
-  ARTIFACTORY_DEPLOY_USERNAME: repox-qa-deployer-sq-ef42e7
-  ARTIFACTORY_DEPLOY_PASSWORD: ENCRYPTED[!d8838c939fe77f3b0a0510774c3b270832646e06cab8e477b35ff776933042105d211e7a0fb8ddcf826ce9f53258c519!]
+  ARTIFACTORY_URL: VAULT[development/kv/data/repox data.url]
+  ARTIFACTORY_PRIVATE_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader
+  ARTIFACTORY_PRIVATE_PASSWORD: VAULT[development/artifactory/token/SonarSource-sonar-scanner-jenkins-private-reader access_token]
+  ARTIFACTORY_ACCESS_TOKEN: VAULT[development/artifactory/token/SonarSource-sonar-scanner-jenkins-private-reader access_token]
+  ARTIFACTORY_DEPLOY_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer
+  ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/SonarSource-sonar-scanner-jenkins-qa-deployer access_token]
   ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
 
-  GCF_ACCESS_TOKEN: ENCRYPTED[!1fb91961a5c01e06e38834e55755231d649dc62eca354593105af9f9d643d701ae4539ab6a8021278b8d9348ae2ce8be!]
-  PROMOTE_URL: ENCRYPTED[!e22ed2e34a8f7a1aea5cff653585429bbd3d5151e7201022140218f9c5d620069ec2388f14f83971e3fd726215bc0f5e!]
+  GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
+  PROMOTE_URL: VAULT[development/kv/data/promote data.url]
 
-  GITHUB_TOKEN: ENCRYPTED[!f458126aa9ed2ac526f220c5acb51dd9cc255726b34761a56fc78d4294c11089502a882888cef0ca7dd4085e72e611a5!]
-
-  BURGR_URL: ENCRYPTED[!c7e294da94762d7bac144abef6310c5db300c95979daed4454ca977776bfd5edeb557e1237e3aa8ed722336243af2d78!]
-  BURGR_USERNAME: ENCRYPTED[!b29ddc7610116de511e74bec9a93ad9b8a20ac217a0852e94a96d0066e6e822b95e7bc1fe152afb707f16b70605fddd3!]
-  BURGR_PASSWORD: ENCRYPTED[!83e130718e92b8c9de7c5226355f730e55fb46e45869149a9223e724bb99656878ef9684c5f8cfef434aa716e87f4cf2!]
+  BURGR_URL: VAULT[development/kv/data/burgr data.url]
+  BURGR_USERNAME: VAULT[development/kv/data/burgr data.cirrus_username]
+  BURGR_PASSWORD: VAULT[development/kv/data/burgr data.cirrus_password]
 
   ### Project variables
   DEPLOY_PULL_REQUEST: true
@@ -48,7 +46,7 @@ build_task:
     cpu: 2
     memory: 3G
   env:
-    SONAR_TOKEN: ENCRYPTED[!b6fd814826c51e64ee61b0b6f3ae621551f6413383f7170f73580e2e141ac78c4b134b506f6288c74faa0dd564c05a29!]
+    SONAR_TOKEN: VAULT[development/kv/data/next data.token]
     SONAR_HOST_URL: https://next.sonarqube.com/sonarqube
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
@@ -105,6 +103,8 @@ promote_task:
     <<: *CONTAINER_DEFINITION
     cpu: 0.5
     memory: 500M
+  env:
+    GITHUB_TOKEN: VAULT[development/github/token/SonarSource-sonar-scanner-jenkins-promotion token]
   maven_cache:
     folder: $CIRRUS_WORKING_DIR/.m2/repository
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,3 @@
-# content of service-account-credentials.json, used to access to Google Cloud Platform
-gcp_credentials: ENCRYPTED[!e5f7207bd8d02d383733bef47e18296ac32e3b7d22eb480354e8dd8fdc0004be45a8a4e72c797bd66ee94eb3340fa363!]
-
 #
 # ENV VARIABLES
 #
@@ -28,11 +25,27 @@ env:
 #
 # RE-USABLE CONFIGS
 #
-container_definition: &CONTAINER_DEFINITION
-  image: us.gcr.io/sonarqube-team/base:j11-m3-latest
-  cluster_name: cirrus-ci-cluster
-  zone: us-central1-a
+docker_build_container_template: &CONTAINER_TEMPLATE
+  dockerfile: its/docker/Dockerfile
+  docker_arguments:
+      CIRRUS_AWS_ACCOUNT: ${CIRRUS_AWS_ACCOUNT}
+  cluster_name: ${CIRRUS_CLUSTER_NAME}
+  builder_role: cirrus-builder
+  builder_image: docker-builder-v*
+  builder_instance_type: t2.small
+  builder_subnet_id: ${CIRRUS_AWS_SUBNET}
+  region: eu-central-1
   namespace: default
+  cpu: 3
+  memory: 8G
+
+container_template: &STD_CONTAINER_TEMPLATE
+  image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j11-m3-latest
+  cluster_name: ${CIRRUS_CLUSTER_NAME}
+  region: eu-central-1
+  namespace: default
+  cpu: 2
+  memory: 3G
 
 only_qa: &ONLY_QA
   only_if: $CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*"
@@ -41,10 +54,8 @@ only_qa: &ONLY_QA
 # TASKS
 #
 build_task:
-  gke_container:
-    <<: *CONTAINER_DEFINITION
-    cpu: 2
-    memory: 3G
+  eks_container:
+    <<: *STD_CONTAINER_TEMPLATE
   env:
     SONAR_TOKEN: VAULT[development/kv/data/next data.token]
     SONAR_HOST_URL: VAULT[development/kv/data/next data.url]
@@ -60,15 +71,7 @@ linux_qa_task:
   depends_on:
     - build
   <<: *ONLY_QA
-  gke_container:
-    dockerfile: its/docker/Dockerfile
-    builder_image_project: sonarqube-team
-    builder_image_name: docker-builder-v20200915
-    cluster_name: cirrus-ci-cluster
-    zone: us-central1-a
-    namespace: default
-    cpu: 3
-    memory: 8G
+  eks_container: *CONTAINER_TEMPLATE
   env:
     BROWSER: chrome
     matrix:
@@ -99,8 +102,8 @@ promote_task:
   depends_on:
     - linux_qa
   <<: *ONLY_QA
-  gke_container:
-    <<: *CONTAINER_DEFINITION
+  eks_container:
+    <<: *STD_CONTAINER_TEMPLATE
     cpu: 0.5
     memory: 500M
   env:

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 SonarQube Scanner for Jenkins
-Copyright (C) 2007-2019 SonarSource SA
+Copyright (C) 2007-2023 SonarSource SA
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ thanks to crawlers written in groovy:
 License
 -------
 
-Copyright 2007-2022 SonarSource.
+Copyright 2007-2023 SonarSource.
 
 Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)

--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -13,7 +13,7 @@
 #------------------------------------------------------------------------------
 
 ARG CIRRUS_AWS_ACCOUNT=275878209202
-FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j11-m3-latest as tools
+FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-g7-latest as tools
 
 USER root
 

--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -63,9 +63,9 @@ RUN dotnet --info
 
 # .NET < 6 requires OpenSSL 1 which is not installed by default on Ubuntu 22.04
 # https://github.com/dotnet/core/issues/7038#issuecomment-1110377345
-RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
-RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
-RUN rm libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb
+RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb
+RUN rm libssl1.1_1.1.1f-1ubuntu2.18_amd64.deb
 RUN apt-get install libicu70
 
 USER sonarsource

--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -9,10 +9,11 @@
 #   docker run -it sonar-scanner-jenkins-qa bash
 #
 # CirrusCI builds the image when needed. No need to manually upload it to
-# Google Cloud Container Registry. See section "gke_container" of .cirrus.yml
+# AWS ECR. See section "eks_container" of .cirrus.yml
 #------------------------------------------------------------------------------
 
-FROM us.gcr.io/sonarqube-team/base:j11-m3-latest
+ARG CIRRUS_AWS_ACCOUNT=275878209202
+FROM ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j11-m3-latest as tools
 
 USER root
 
@@ -29,9 +30,9 @@ RUN apt-get install -y nodejs
 #==============================================================================
 # Google Chrome, for integration tests
 #==============================================================================
-ARG CHROME_VERSION=85.0.4183.102-1
+ARG CHROME_VERSION=108.0.5359.94-1
 RUN echo "Using Chrome version: $CHROME_VERSION" \
-  && wget --no-verbose -O /tmp/chrome_amd64.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+  && wget --no-verbose -O /tmp/chrome_amd64.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
   # Ignore install errors; we will try and fix them below.
   && dpkg -i /tmp/chrome_amd64.deb || true
 RUN apt-get install -fy
@@ -59,5 +60,12 @@ RUN echo "Installing dotnet 2.2" \
   && chmod -R 755 /usr/share/dotnet \
   && chmod 755 /usr/bin/dotnet
 RUN dotnet --info
+
+# .NET < 6 requires OpenSSL 1 which is not installed by default on Ubuntu 22.04
+# https://github.com/dotnet/core/issues/7038#issuecomment-1110377345
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN rm libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN apt-get install libicu70
 
 USER sonarsource

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -80,6 +80,9 @@
             <systemProperties>
               <maven.home>${maven.home}</maven.home>
             </systemProperties>
+            <argLine>
+                --add-exports java.base/sun.reflect.annotation=ALL-UNNAMED
+            </argLine>
           </configuration>
         </plugin>
       </plugins>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.34.0.2692</version>
+      <version>3.40.0.183</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -18,7 +18,7 @@
   <inceptionYear>2013</inceptionYear>
 
   <properties>
-    <sonar-ws.version>8.9.0.43852</sonar-ws.version>
+    <sonar-ws.version>9.9.0.65466</sonar-ws.version>
     <maven.compiler.release>8</maven.compiler.release>
   </properties>
 

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>60.0.52</version>
+    <version>65.0.218</version>
     <relativePath/>
   </parent>
 

--- a/its/projects/abacus/pom.xml
+++ b/its/projects/abacus/pom.xml
@@ -54,6 +54,7 @@
     <sonar.pluginName>Abacus</sonar.pluginName>
     <sonar.pluginClass>org.sonar.plugins.abacus.AbacusPlugin</sonar.pluginClass>
     <sonar.scm.disabled>true</sonar.scm.disabled>
+    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
   </properties>
 
   <dependencies>
@@ -79,8 +80,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/its/src/main/java/com/sonar/it/jenkins/FilesystemScm.java
+++ b/its/src/main/java/com/sonar/it/jenkins/FilesystemScm.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/main/java/com/sonar/it/jenkins/MSBuildScannerInstallation.java
+++ b/its/src/main/java/com/sonar/it/jenkins/MSBuildScannerInstallation.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/main/java/com/sonar/it/jenkins/SonarScannerInstallation.java
+++ b/its/src/main/java/com/sonar/it/jenkins/SonarScannerInstallation.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -31,6 +31,7 @@ import org.sonarqube.ws.Qualitygates;
 import org.sonarqube.ws.client.PostRequest;
 import org.sonarqube.ws.client.qualitygates.CreateConditionRequest;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.sonar.it.jenkins.utility.JenkinsUtils.DEFAULT_SONARQUBE_INSTALLATION;
 import static com.sonar.it.jenkins.utility.JenkinsUtils.FailedExecutionException;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,15 +77,16 @@ public class SonarPluginTest extends SonarPluginTestSuite {
 
   @Test
   public void scan_project_ms_build_net_core_scanner() {
-    MSBuildScannerInstallation.install(jenkins, EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION, false);
-    MSBuildScannerInstallation.install(jenkins, MS_BUILD_RECENT_VERSION, true);
+    checkState(!OLDEST_INSTALLABLE_MSBUILD_VERSION.equals(LATEST_INSTALLABLE_MSBUILD_VERSION), "The test aims to install 2 different versions of the Scanner MSBuild, but they are not.");
+    MSBuildScannerInstallation.install(jenkins, OLDEST_INSTALLABLE_MSBUILD_VERSION, false);
+    MSBuildScannerInstallation.install(jenkins, LATEST_INSTALLABLE_MSBUILD_VERSION, true);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
 
     String jobName = "csharp-core";
     String projectKey = "csharp-core";
     assertThat(getProject(projectKey)).isNull();
     jenkinsOrch
-      .newFreestyleJobWithScannerForMsBuild(jobName, null, consoleNetCoreFolder, projectKey, "CSharp NetCore", "1.0", MS_BUILD_RECENT_VERSION, "NetCoreConsoleApp.sln", true)
+      .newFreestyleJobWithScannerForMsBuild(jobName, null, consoleNetCoreFolder, projectKey, "CSharp NetCore", "1.0", LATEST_INSTALLABLE_MSBUILD_VERSION, "NetCoreConsoleApp.sln", true)
       .executeJob(jobName);
 
     waitForComputationOnSQServer();

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -222,7 +222,13 @@ public class SonarPluginTest extends SonarPluginTestSuite {
     String previousDefault = getDefaultQualityGateName();
     Qualitygates.CreateResponse simple = wsClient.qualitygates().create(new org.sonarqube.ws.client.qualitygates.CreateRequest().setName("AlwaysFail"));
     setDefaultQualityGate(simple.getName());
-    wsClient.qualitygates().createCondition(new CreateConditionRequest().setGateId(simple.getId()).setMetric("lines").setOp("GT").setError("0"));
+    wsClient.wsConnector().call(
+      new PostRequest("api/qualitygates/create_condition")
+        .setParam("gateName", simple.getName())
+        .setParam("metric", "lines")
+        .setParam("op", "GT")
+        .setParam("error", "0")
+    );
 
     try {
       String script = SonarQubeScriptBuilder.newScript()

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTestSuite.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTestSuite.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTestSuite.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTestSuite.java
@@ -21,7 +21,8 @@ package com.sonar.it.jenkins;
 
 import com.google.common.net.UrlEscapers;
 import com.sonar.it.jenkins.utility.JenkinsUtils;
-import com.sonar.it.jenkins.utility.ScannerSupportedVersionProvider;
+import com.sonar.it.jenkins.utility.InstallableScannerVersionsProvider;
+import com.sonar.it.jenkins.utility.InstallableScannerVersionsProvider.InstallableScannerVersions;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SynchronousAnalyzer;
 import com.sonar.orchestrator.container.Server;
@@ -55,12 +56,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @WithPlugins({"sonar", "credentials@2.6.1", "filesystem_scm"})
 public class SonarPluginTestSuite extends AbstractJUnitTest {
-
-  private static final ScannerSupportedVersionProvider SCANNER_VERSION_PROVIDER = new ScannerSupportedVersionProvider();
   private static final String SECRET = "very_secret_secret";
   private static String DEFAULT_QUALITY_GATE_NAME;
-  protected static String EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION;
-  protected static final String MS_BUILD_RECENT_VERSION = "4.7.1.2311";
+  protected static String OLDEST_INSTALLABLE_MSBUILD_VERSION;
+  protected static String LATEST_INSTALLABLE_MSBUILD_VERSION;
   protected static WsClient wsClient;
   protected JenkinsUtils jenkinsOrch;
   protected final File csharpFolder = new File("projects", "csharp");
@@ -83,8 +82,11 @@ public class SonarPluginTestSuite extends AbstractJUnitTest {
       .build());
     DEFAULT_QUALITY_GATE_NAME = getDefaultQualityGateName();
 
-    EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION = SCANNER_VERSION_PROVIDER
-        .getEarliestSupportedVersion("sonar-scanner-msbuild");
+    InstallableScannerVersionsProvider installableScannerVersionsProvider = new InstallableScannerVersionsProvider();
+    InstallableScannerVersions installableMSBuildScannerVersions = installableScannerVersionsProvider.getScannerInstallableVersions("sonar-scanner-msbuild");
+
+    OLDEST_INSTALLABLE_MSBUILD_VERSION = installableMSBuildScannerVersions.getOldestVersion();
+    LATEST_INSTALLABLE_MSBUILD_VERSION = installableMSBuildScannerVersions.getLatestVersion();
   }
 
   @Before

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginWindowsTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginWindowsTest.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginWindowsTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginWindowsTest.java
@@ -40,12 +40,12 @@ public class SonarPluginWindowsTest extends SonarPluginTestSuite {
   @Test
   @WithPlugins({"workflow-aggregator", "msbuild"})
   public void msbuild_pipeline() {
-    MSBuildScannerInstallation.install(jenkins, EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION, false);
+    MSBuildScannerInstallation.install(jenkins, OLDEST_INSTALLABLE_MSBUILD_VERSION, false);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
 
     String script = "withSonarQubeEnv('" + DEFAULT_SONARQUBE_INSTALLATION + "') {\n"
       + "  bat 'xcopy " + Paths.get("projects/csharp").toAbsolutePath().toString().replaceAll("\\\\", quoteReplacement("\\\\")) + " . /s /e /y'\n"
-      + "  def sqScannerMsBuildHome = tool 'Scanner for MSBuild " + EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION + "'\n"
+      + "  def sqScannerMsBuildHome = tool 'Scanner for MSBuild " + OLDEST_INSTALLABLE_MSBUILD_VERSION + "'\n"
       + "  bat \"${sqScannerMsBuildHome}\\\\MSBuild.SonarQube.Runner.exe begin /k:csharp /n:CSharp /v:1.0\"\n"
       + "  bat '\\\"%MSBUILD_PATH%\\\" /t:Rebuild'\n"
       + "  bat \"${sqScannerMsBuildHome}\\\\MSBuild.SonarQube.Runner.exe end\"\n"
@@ -57,7 +57,7 @@ public class SonarPluginWindowsTest extends SonarPluginTestSuite {
   @WithPlugins({"msbuild"})
   public void freestyle_job_with_scanner_for_ms_build_2_3_2() {
     MSBuildScannerInstallation.install(jenkins, "2.3.2.573", false);
-    MSBuildScannerInstallation.install(jenkins, EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION, false);
+    MSBuildScannerInstallation.install(jenkins, OLDEST_INSTALLABLE_MSBUILD_VERSION, false);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR)
       .configureMSBuild(ORCHESTRATOR);
 
@@ -79,7 +79,7 @@ public class SonarPluginWindowsTest extends SonarPluginTestSuite {
   @WithPlugins({"msbuild"})
   public void freestyle_job_with_scanner_for_ms_build_3_0() {
     MSBuildScannerInstallation.install(jenkins, "2.3.2.573", false);
-    MSBuildScannerInstallation.install(jenkins, EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION, false);
+    MSBuildScannerInstallation.install(jenkins, OLDEST_INSTALLABLE_MSBUILD_VERSION, false);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR)
       .configureMSBuild(ORCHESTRATOR);
 
@@ -88,7 +88,7 @@ public class SonarPluginWindowsTest extends SonarPluginTestSuite {
     assertThat(getProject(projectKey)).isNull();
     Build result = jenkinsOrch
       .newFreestyleJobWithScannerForMsBuild(jobName, null, jsFolder, projectKey, "JS with space", "1.0",
-        EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION, null, false)
+        OLDEST_INSTALLABLE_MSBUILD_VERSION, null, false)
       .executeJobQuietly(jobName);
 
     assertThat(result.getConsole())
@@ -101,7 +101,7 @@ public class SonarPluginWindowsTest extends SonarPluginTestSuite {
   @Test
   @WithPlugins({"msbuild"})
   public void freestyle_job_with_scanner_for_ms_build() throws FailedExecutionException {
-    MSBuildScannerInstallation.install(jenkins, MS_BUILD_RECENT_VERSION, false);
+    MSBuildScannerInstallation.install(jenkins, LATEST_INSTALLABLE_MSBUILD_VERSION, false);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR)
       .configureMSBuild(ORCHESTRATOR);
 
@@ -109,7 +109,7 @@ public class SonarPluginWindowsTest extends SonarPluginTestSuite {
     String projectKey = "csharp";
     assertThat(getProject(projectKey)).isNull();
     jenkinsOrch
-      .newFreestyleJobWithScannerForMsBuild(jobName, null, consoleApp1Folder, projectKey, "CSharp", "1.0", MS_BUILD_RECENT_VERSION, "ConsoleApplication1.sln", false)
+      .newFreestyleJobWithScannerForMsBuild(jobName, null, consoleApp1Folder, projectKey, "CSharp", "1.0", LATEST_INSTALLABLE_MSBUILD_VERSION, "ConsoleApplication1.sln", false)
       .executeJob(jobName);
 
     waitForComputationOnSQServer();

--- a/its/src/test/java/com/sonar/it/jenkins/utility/JenkinsUtils.java
+++ b/its/src/test/java/com/sonar/it/jenkins/utility/JenkinsUtils.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/test/java/com/sonar/it/jenkins/utility/JenkinsUtils.java
+++ b/its/src/test/java/com/sonar/it/jenkins/utility/JenkinsUtils.java
@@ -61,6 +61,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.sonarqube.ws.Qualitygates;
 import org.sonarqube.ws.UserTokens;
 import org.sonarqube.ws.client.HttpConnector;
+import org.sonarqube.ws.client.PostRequest;
 import org.sonarqube.ws.client.WsClient;
 import org.sonarqube.ws.client.WsClientFactories;
 import org.sonarqube.ws.client.qualitygates.ListRequest;
@@ -338,9 +339,12 @@ public class JenkinsUtils {
     Qualitygates.ListWsResponse qualityGates = wsClient.qualitygates().list(new ListRequest());
     assertThat(qualityGates.getQualitygatesList().size()).isPositive();
 
-    String id = qualityGates.getQualitygates(0).getId();
-    wsClient.qualitygates().setAsDefault(new SetAsDefaultRequest().setId(id));
-    System.out.println("Set default QG: " + id);
+    String name = qualityGates.getQualitygates(0).getName();
+    wsClient.wsConnector().call(
+      new PostRequest("api/qualitygates/set_as_default").setParam("name", name)
+    );
+
+    System.out.println("Set default QG: " + name);
   }
 
   public String generateToken(Orchestrator orchestrator) {

--- a/its/src/test/java/com/sonar/it/jenkins/utility/RunOnlyOnWindows.java
+++ b/its/src/test/java/com/sonar/it/jenkins/utility/RunOnlyOnWindows.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/test/java/com/sonar/it/jenkins/utility/ScannerSupportedVersionProvider.java
+++ b/its/src/test/java/com/sonar/it/jenkins/utility/ScannerSupportedVersionProvider.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/src/test/java/com/sonar/it/jenkins/utility/SonarQubeScriptBuilder.java
+++ b/its/src/test/java/com/sonar/it/jenkins/utility/SonarQubeScriptBuilder.java
@@ -1,6 +1,6 @@
 /*
  * Jenkins :: Integration Tests
- * Copyright (C) 2013-2022 SonarSource SA
+ * Copyright (C) 2013-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
       <dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
-        <version>3.8.0</version>
+        <version>3.9.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <license.name>GNU LGPL v3</license.name>
     <license.owner>SonarSource SA</license.owner>
     <license.title>${project.name}</license.title>
-    <license.years>${project.inceptionYear}-2022</license.years>
+    <license.years>${project.inceptionYear}-2023</license.years>
     <license.mailto>mailto:info AT sonarsource DOT com</license.mailto>
 
     <artifactsToPublish>${project.groupId}:${project.artifactId}:hpi${project.groupId}:${project.artifactId}:json:cyclonedx</artifactsToPublish>

--- a/src/main/java/hudson/plugins/sonar/AbstractMsBuildSQRunner.java
+++ b/src/main/java/hudson/plugins/sonar/AbstractMsBuildSQRunner.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/GlobalCredentialMigrator.java
+++ b/src/main/java/hudson/plugins/sonar/GlobalCredentialMigrator.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerInstallation.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerInstallation.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -49,7 +50,7 @@ public class MsBuildSQRunnerInstallation extends ToolInstallation implements Env
   private static String testExeName = null;
 
   @DataBoundConstructor
-  public MsBuildSQRunnerInstallation(String name, String home, List<? extends ToolProperty<?>> properties) {
+  public MsBuildSQRunnerInstallation(String name, @CheckForNull String home, List<? extends ToolProperty<?>> properties) {
     super(Util.fixEmptyAndTrim(name), Util.fixEmptyAndTrim(home), properties);
   }
 

--- a/src/main/java/hudson/plugins/sonar/MsBuildSonarQubeRunnerInstaller.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSonarQubeRunnerInstaller.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
+++ b/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/SonarInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarInstallation.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/SonarPlugin.java
+++ b/src/main/java/hudson/plugins/sonar/SonarPlugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/SonarPublisher.java
+++ b/src/main/java/hudson/plugins/sonar/SonarPublisher.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/SonarRunnerInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerInstallation.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/SonarRunnerInstaller.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerInstaller.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/SonarAnalysisAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarAnalysisAction.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/SonarBuildBadgeAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarBuildBadgeAction.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/SonarBuildBadgeActionFactory.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarBuildBadgeActionFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/SonarCacheAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarCacheAction.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/SonarMarkerAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarMarkerAction.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/SonarProjectActionFactory.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarProjectActionFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/SonarProjectIconAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarProjectIconAction.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/SonarProjectPageAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarProjectPageAction.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/action/package-info.java
+++ b/src/main/java/hudson/plugins/sonar/action/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/client/HttpClient.java
+++ b/src/main/java/hudson/plugins/sonar/client/HttpClient.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/client/MessageException.java
+++ b/src/main/java/hudson/plugins/sonar/client/MessageException.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/client/OkHttpClientSingleton.java
+++ b/src/main/java/hudson/plugins/sonar/client/OkHttpClientSingleton.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/client/ProjectInformation.java
+++ b/src/main/java/hudson/plugins/sonar/client/ProjectInformation.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
+++ b/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/client/WsClient.java
+++ b/src/main/java/hudson/plugins/sonar/client/WsClient.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/client/package-info.java
+++ b/src/main/java/hudson/plugins/sonar/client/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/AbstractSonarPublisherSlicerSpec.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/AbstractSonarPublisherSlicerSpec.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/AbstractSonarRunnerBuilderSlicerSpec.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/AbstractSonarRunnerBuilderSlicerSpec.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/SonarPublisherAdditionalPropertiesSlicer.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/SonarPublisherAdditionalPropertiesSlicer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/SonarPublisherBranchSlicer.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/SonarPublisherBranchSlicer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/SonarPublisherJdkSlicer.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/SonarPublisherJdkSlicer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/SonarPublisherSQServerSlicer.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/SonarPublisherSQServerSlicer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderJdkSlicer.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderJdkSlicer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderSQRunnerSlicer.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderSQRunnerSlicer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderSQServerSlicer.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderSQServerSlicer.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/configurationslicing/package-info.java
+++ b/src/main/java/hudson/plugins/sonar/configurationslicing/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/model/TriggersConfig.java
+++ b/src/main/java/hudson/plugins/sonar/model/TriggersConfig.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/model/package-info.java
+++ b/src/main/java/hudson/plugins/sonar/model/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/package-info.java
+++ b/src/main/java/hudson/plugins/sonar/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/BuilderUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/BuilderUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/ExtendedArgumentListBuilder.java
+++ b/src/main/java/hudson/plugins/sonar/utils/ExtendedArgumentListBuilder.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/JenkinsRouter.java
+++ b/src/main/java/hudson/plugins/sonar/utils/JenkinsRouter.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/Logger.java
+++ b/src/main/java/hudson/plugins/sonar/utils/Logger.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/MaskPasswordsOutputStream.java
+++ b/src/main/java/hudson/plugins/sonar/utils/MaskPasswordsOutputStream.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/SonarMaven.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarMaven.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/Version.java
+++ b/src/main/java/hudson/plugins/sonar/utils/Version.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/hudson/plugins/sonar/utils/package-info.java
+++ b/src/main/java/hudson/plugins/sonar/utils/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHook.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHook.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookCrumbExclusion.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookCrumbExclusion.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/package-info.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/BaseTest.java
+++ b/src/test/java/hudson/plugins/sonar/BaseTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/GlobalCredentialMigratorTest.java
+++ b/src/test/java/hudson/plugins/sonar/GlobalCredentialMigratorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerBeginTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerBeginTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerEndTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerEndTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerInstallationTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerInstallationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/MsBuildSonarQubeRunnerInstallerTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSonarQubeRunnerInstallerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/SonarBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarBuildWrapperTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/SonarGlobalConfigurationTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarGlobalConfigurationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/SonarInstallationTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarInstallationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/SonarPublisherTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarPublisherTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/SonarTestCase.java
+++ b/src/test/java/hudson/plugins/sonar/SonarTestCase.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/action/SonarAnalysisActionTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarAnalysisActionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/action/SonarBuildBadgeActionFactoryTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarBuildBadgeActionFactoryTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/action/SonarBuildBadgeActionTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarBuildBadgeActionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/action/SonarCacheActionTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarCacheActionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/action/SonarProjectActionFactoryTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarProjectActionFactoryTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/action/SonarProjectIconActionTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarProjectIconActionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/action/SonarProjectPageActionTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarProjectPageActionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/casc/CasCMinimalTest.java
+++ b/src/test/java/hudson/plugins/sonar/casc/CasCMinimalTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/casc/CasCToolTest.java
+++ b/src/test/java/hudson/plugins/sonar/casc/CasCToolTest.java
@@ -1,0 +1,113 @@
+/*
+ * SonarQube Scanner for Jenkins
+ * Copyright (C) 2007-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package hudson.plugins.sonar.casc;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+
+import hudson.plugins.sonar.MsBuildSQRunnerInstallation;
+import hudson.plugins.sonar.MsBuildSonarQubeRunnerInstaller;
+import hudson.plugins.sonar.SonarRunnerInstallation;
+import hudson.plugins.sonar.SonarRunnerInstaller;
+import hudson.tools.InstallSourceProperty;
+import hudson.tools.ToolDescriptor;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolProperty;
+import hudson.tools.ToolPropertyDescriptor;
+import hudson.util.DescribableList;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import jenkins.model.Jenkins;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class CasCToolTest extends RoundTripAbstractTest {
+
+  @Override
+  protected String configResource() {
+    return "config-tools.yaml";
+  }
+
+  @Override
+  protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+    checkMSBuildSQInstallations(restartableJenkinsRule.j.jenkins);
+    checkSQInstallations(restartableJenkinsRule.j.jenkins);
+  }
+
+  private void checkSQInstallations(Jenkins j) {
+      final ToolDescriptor<SonarRunnerInstallation> descriptor = (ToolDescriptor) j.getDescriptor(SonarRunnerInstallation.class);
+      final ToolInstallation[] installations = descriptor.getInstallations();
+      assertThat(installations, arrayWithSize(2));
+
+      ToolInstallation withInstaller = installations[0];
+      assertEquals("SonarQube Scanner", withInstaller.getName());
+
+      final DescribableList<ToolProperty<?>, ToolPropertyDescriptor> properties = withInstaller.getProperties();
+      assertThat(properties, hasSize(1));
+      final ToolProperty<?> property = properties.get(0);
+
+      assertThat(((InstallSourceProperty)property).installers,
+        containsInAnyOrder(
+          allOf(instanceOf(SonarRunnerInstaller.class))
+        ));
+
+      ToolInstallation withoutInstaller = installations[1];
+      assertThat(withoutInstaller,
+        allOf(
+          hasProperty("name", equalTo("local SonarQube Scanner")),
+          hasProperty("home", equalTo("/home/jenkins/agent/tools/sonarscanner")
+        )));
+  }
+
+  private void checkMSBuildSQInstallations(Jenkins j) {
+    final ToolDescriptor<MsBuildSQRunnerInstallation> descriptor = (ToolDescriptor) j.getDescriptor(MsBuildSQRunnerInstallation.class);
+    final ToolInstallation[] installations = descriptor.getInstallations();
+    assertThat(installations, arrayWithSize(2));
+
+    ToolInstallation withInstaller = installations[0];
+    assertEquals("SonarQube MSScanner", withInstaller.getName());
+
+    final DescribableList<ToolProperty<?>, ToolPropertyDescriptor> properties = withInstaller.getProperties();
+    assertThat(properties, hasSize(1));
+    final ToolProperty<?> property = properties.get(0);
+
+    assertThat(((InstallSourceProperty)property).installers,
+      containsInAnyOrder(
+        allOf(instanceOf(MsBuildSonarQubeRunnerInstaller.class))
+      ));
+
+    ToolInstallation withoutInstaller = installations[1];
+    assertThat(withoutInstaller,
+      allOf(
+        hasProperty("name", equalTo("local SonarQube MSScanner")),
+        hasProperty("home", equalTo("/home/jenkins/agent/tools/msscanner")
+      )));
+  }
+
+  @Override
+  protected String stringInLogExpected() {
+    return "MsBuildSQRunnerInstallation";
+  }
+}

--- a/src/test/java/hudson/plugins/sonar/casc/CasCTriggersTest.java
+++ b/src/test/java/hudson/plugins/sonar/casc/CasCTriggersTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/client/HttpClientTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/HttpClientTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/client/MessageExceptionTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/MessageExceptionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/client/OkHttpClientSingletonTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/OkHttpClientSingletonTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/client/ProjectInformationTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/ProjectInformationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/client/SQProjectResolverTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/SQProjectResolverTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/client/WsClientTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/WsClientTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherAdditionalPropertiesSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherAdditionalPropertiesSlicerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherBranchSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherBranchSlicerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherJdkSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherJdkSlicerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherSQServerSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarPublisherSQServerSlicerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderJdkSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderJdkSlicerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderSQRunnerSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderSQRunnerSlicerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderSQServerSlicerTest.java
+++ b/src/test/java/hudson/plugins/sonar/configurationslicing/SonarRunnerBuilderSQServerSlicerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/model/TriggersConfigTest.java
+++ b/src/test/java/hudson/plugins/sonar/model/TriggersConfigTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/utils/BuilderUtilsTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/BuilderUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/utils/ExtendedArgumentListBuilderTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/ExtendedArgumentListBuilderTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/utils/LoggerTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/LoggerTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/utils/MaskPasswordsOutputStreamTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/MaskPasswordsOutputStreamTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/utils/SonarMavenTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarMavenTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/hudson/plugins/sonar/utils/VersionTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/VersionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/NetworkUtils.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/NetworkUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookCrumbExclusionTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookCrumbExclusionTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarQube Scanner for Jenkins
- * Copyright (C) 2007-2022 SonarSource SA
+ * Copyright (C) 2007-2023 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/src/test/resources/hudson/plugins/sonar/casc/config-tools.yaml
+++ b/src/test/resources/hudson/plugins/sonar/casc/config-tools.yaml
@@ -1,0 +1,21 @@
+tool:
+  sonarRunnerInstallation:
+    installations:
+    - name: "SonarQube Scanner"
+      properties:
+      - installSource:
+          installers:
+          - sonarRunnerInstaller:
+              id: "4.8.0.2856"
+    - name: "local SonarQube Scanner"
+      home: "/home/jenkins/agent/tools/sonarscanner"
+  msBuildSQRunnerInstallation:
+    installations:
+    - name: "SonarQube MSScanner"
+      properties:
+      - installSource:
+          installers:
+          - msBuildSonarQubeRunnerInstaller:
+              id: "5.11.0.60783-netcore3"
+    - name: "local SonarQube MSScanner"
+      home: "/home/jenkins/agent/tools/msscanner"


### PR DESCRIPTION
Add annotation on MsBuildSQRunnerInstallation default constructor to instruct the CasC plugin that home variable is optional and not required.
Add CasC test cases for both MsBuildSQRunnerInstallation and SonarRunnerInstallation

- [X] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [X] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONARJNKNS) ticket available, please make your commits and pull request start with the ticket ID (SONARJNKNS-XXXX)