### PR TITLE
Use `io.jenkins.plugins:commons-lang3-api`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,9 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.11</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+      <version>3.12.0-36.vd97de6465d5b_</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>commons-lang3-api</artifactId>
-      <version>3.12.0-36.vd97de6465d5b_</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>commons-lang3-api</artifactId>
+      <version>3.12.0-36.vd97de6465d5b_</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
Use [`io.jenkins.plugins:commons-lang3-api`](https://plugins.jenkins.io/commons-lang3-api) instead of `org.apache.commons:commons-lang3`.
All tests still pass. I don't think this needs new tests.