### PR TITLE
Support sonar.token (>=10.0) and sonar.login (9.9 LTS)

### DIFF
--- a/its/src/test/java/com/sonar/it/jenkins/utility/JenkinsUtils.java
+++ b/its/src/test/java/com/sonar/it/jenkins/utility/JenkinsUtils.java
@@ -372,7 +372,9 @@ public class JenkinsUtils {
   private String getMavenParams(Orchestrator orchestrator) {
     Version serverVersion = orchestrator.getServer().version();
 
-    if (serverVersion.isGreaterThanOrEquals(5, 3)) {
+    if (serverVersion.isGreaterThanOrEquals(10, 0)) {
+        return "$SONAR_MAVEN_GOAL -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.token=$SONAR_AUTH_TOKEN";
+    } else if (serverVersion.isGreaterThanOrEquals(5, 3)) {
       return "$SONAR_MAVEN_GOAL -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN";
     } else {
       return "$SONAR_MAVEN_GOAL -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_LOGIN -Dsonar.password=$SONAR_PASSWORD"

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
@@ -110,7 +110,10 @@ public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
     map.put("sonar.host.url", inst.getServerUrl());
     String token = inst.getServerAuthenticationToken(run);
     if (!StringUtils.isBlank(token)) {
+        // add sonar.login for LTS Version 9.9
       map.put("sonar.login", token);
+      // add sonar.token for Version 10.x
+      map.put("sonar.token", token);
     }
 
     return map;
@@ -129,7 +132,7 @@ public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
     for (Map.Entry<String, String> e : props.entrySet()) {
       if (!StringUtils.isEmpty(e.getValue())) {
         // expand macros using environment variables and hide token
-        boolean hide = e.getKey().contains("sonar.login");
+        boolean hide = e.getKey().contains("sonar.login") || e.getKey().contains("sonar.token");
         args.addKeyValuePair("/d:", e.getKey(), env.expand(e.getValue()), hide);
       }
     }

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
@@ -91,7 +91,7 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
     for (Map.Entry<String, String> e : props.entrySet()) {
       if (!StringUtils.isEmpty(e.getValue())) {
         // expand macros using environment variables and hide token
-        boolean hide = e.getKey().contains("sonar.login");
+        boolean hide = e.getKey().contains("sonar.login") || e.getKey().contains("sonar.token");
         args.addKeyValuePair("/d:", e.getKey(), env.expand(e.getValue()), hide);
       }
     }
@@ -104,7 +104,10 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
 
     String token = inst.getServerAuthenticationToken(run);
     if (!StringUtils.isBlank(token)) {
+        // add sonar.login for LTS Version 9.9
       map.put("sonar.login", token);
+      // add sonar.token for LTS Version 10.x
+      map.put("sonar.token", token);
     }
 
     return map;

--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -146,7 +146,10 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
     StringBuilder sb = new StringBuilder();
     sb.append("{ \"sonar.host.url\" : \"").append(escapeJson(hostUrl)).append("\"");
     if (!token.isEmpty()) {
+        // add sonar.login for LTS Version 9.9
       sb.append(", \"sonar.login\" : \"").append(escapeJson(token)).append("\"");
+      // add sonar.token for Version 10.x
+      sb.append(", \"sonar.token\" : \"").append(escapeJson(token)).append("\"");
     }
     String additionalAnalysisProperties = inst.getAdditionalAnalysisProperties();
     if (additionalAnalysisProperties != null) {

--- a/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
@@ -363,7 +363,10 @@ public class SonarRunnerBuilder extends Builder {
       args.append("sonar.host.url", si.getServerUrl());
       String token = si.getServerAuthenticationToken(build);
       if (StringUtils.isNotBlank(token)) {
-        args.appendMasked("sonar.login", token);
+          // add sonar.login for LTS Version 9.9
+          args.appendMasked("sonar.login", token);
+          // add sonar.token for Version 10.x
+          args.appendMasked("sonar.token", token);
       }
     }
 

--- a/src/main/java/hudson/plugins/sonar/utils/SonarMaven.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarMaven.java
@@ -97,7 +97,10 @@ public final class SonarMaven extends Maven {
 
     String token = getInstallation().getServerAuthenticationToken(build);
     if (StringUtils.isNotBlank(token)) {
+      // add sonar.login for LTS Version 9.9
       argsBuilder.appendMasked("sonar.login", token);
+      // add sonar.token for Version 10.x
+      argsBuilder.appendMasked("sonar.token", token);
     }
 
     if (build instanceof MavenModuleSetBuild) {

--- a/src/test/java/hudson/plugins/sonar/SonarBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarBuildWrapperTest.java
@@ -133,7 +133,7 @@ public class SonarBuildWrapperTest extends SonarTestCase {
     assertThat(map).containsEntry("SONAR_EXTRA_PROPS", "-Dkey=myValue -X");
 
     assertThat(map).containsEntry("SONARQUBE_SCANNER_PARAMS",
-      "{ \"sonar.host.url\" : \"http:\\/\\/myserver:10000\", \"sonar.login\" : \"" + MYTOKEN + "\", \"key\" : \"myValue\"}");
+      "{ \"sonar.host.url\" : \"http:\\/\\/myserver:10000\", \"sonar.login\" : \"" + MYTOKEN + "\",  \"sonar.token\" : \"" + MYTOKEN + "\", \"key\" : \"myValue\"}");
   }
 
   @Test

--- a/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
@@ -137,7 +137,8 @@ public class SonarRunnerBuilderTest extends SonarTestCase {
     builder.populateConfiguration(argsBuilder, build, build.getWorkspace(), listener, env, installation);
 
     assertThat(args.toStringWithQuote())
-      .contains("-Dsonar.login=token");
+      .contains("-Dsonar.login=token")
+      .contains("-Dsonar.token=token");
   }
 
   /**


### PR DESCRIPTION
Since Sonar 10.0 a warning appears when running sonar analysis in jenkins:

The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.