### PR TITLE
Update sonar-ws to 9.9.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-ws</artifactId>
-      <version>6.7</version>
+      <version>9.9.1.69595</version>
     </dependency>
     <dependency>
       <!-- needed for SonarPublisher -->


### PR DESCRIPTION
Please see https://issues.jenkins.io/browse/JENKINS-70694. 

There is an issue that this plugin  causes Jenkins to become unresponsive. This plugin blocks threads on calls to SonarQube. These calls do not have a timeout, so eventually some threadpool in Jenkins gets exhausted, causing it to become (at least partially) unresponsive. 

According to the comments, updating the sonar-ws library to a more recent version (current version is 6.7 from ~2017). 