### PR TITLE
Update sonar-ws to 9.9.1.x 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
   </ciManagement>
 
   <properties>
-    <revision>2.16</revision>
-    <changelist>-SNAPSHOT</changelist>
+    <revision>2.15.1</revision>
+    <changelist></changelist>
     <gitHubRepo>jenkinsci/sonarqube-plugin</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <hudson.version>${project.parent.version}</hudson.version>
@@ -82,7 +82,17 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.16.3</version>
+        <version>3.21.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>1.6.20</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>1.6.20</version>
       </dependency>
       <dependency>
         <groupId>com.jcraft</groupId>
@@ -161,7 +171,7 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-ws</artifactId>
-      <version>6.7</version>
+      <version>9.9.1.69595</version>
     </dependency>
     <dependency>
       <!-- needed for SonarPublisher -->
@@ -195,6 +205,8 @@
       <artifactId>commons-codec</artifactId>
       <version>1.13</version>
     </dependency>
+
+
 
     <!-- Test deps -->
     <dependency>

--- a/src/main/java/hudson/plugins/sonar/client/OkHttpClientSingleton.java
+++ b/src/main/java/hudson/plugins/sonar/client/OkHttpClientSingleton.java
@@ -19,11 +19,28 @@
  */
 package hudson.plugins.sonar.client;
 
+import hudson.plugins.sonar.utils.Logger;
 import okhttp3.OkHttpClient;
 import org.sonarqube.ws.client.OkHttpClientBuilder;
+import org.springframework.beans.InvalidPropertyException;
 
 public class OkHttpClientSingleton {
-  private static final OkHttpClient okHttpClient = new OkHttpClientBuilder().setUserAgent("Scanner for Jenkins").build();
+  private static final long TIME_OUT;
+  static {
+    String timeoutSysPropValue = System.getProperty("plugin.sonar.http.timeout", "10000");
+    try {
+      long value = Long.parseLong(timeoutSysPropValue);
+      TIME_OUT = value;
+    } catch (NumberFormatException e) {
+      String msg = "Unable to create Sonar HTTP client: Invalid value for timeout (system) property 'plugin.sonar.http.timeout': " + timeoutSysPropValue;
+      Logger.LOG.severe(msg);
+      throw new Error(msg, e);
+    }
+  }
+  private static final OkHttpClient okHttpClient = new OkHttpClientBuilder().
+          setConnectTimeoutMs(TIME_OUT).
+          setReadTimeoutMs(TIME_OUT).
+          setUserAgent("Scanner for Jenkins").build();
 
   private OkHttpClientSingleton() {
     // Nothing to do


### PR DESCRIPTION
Please see https://issues.jenkins.io/browse/JENKINS-70694.

There is an issue that this plugin causes Jenkins to become unresponsive. This plugin blocks threads on calls to SonarQube. These calls do not have a timeout, so eventually some threadpool in Jenkins gets exhausted, causing it to become (at least partially) unresponsive.

According to the comments, updating the sonar-ws library to a more recent version (current version is 6.7 from ~2017).

This PR updates SQ to subject version as well it introduces timeouts for HTTP calls.